### PR TITLE
Show token usage and cost for OpenAI models

### DIFF
--- a/api/app/clients/BaseClient.js
+++ b/api/app/clients/BaseClient.js
@@ -727,7 +727,7 @@ class BaseClient {
       }
     }
 
-    this.responsePromise = this.saveMessageToDatabase(responseMessage, saveOptions, user);
+    this.responsePromise = this.saveMessageToDatabase({ ...responseMessage, tmp_usage: this.usage }, saveOptions, user);
     this.savedMessageIds.add(responseMessage.messageId);
     delete responseMessage.tokenCount;
     return responseMessage;

--- a/api/server/controllers/AskController.js
+++ b/api/server/controllers/AskController.js
@@ -105,6 +105,8 @@ const AskController = async (req, res, next, initializeClient, addTitle) => {
     let response = await client.sendMessage(text, messageOptions);
     response.endpoint = endpointOption.endpoint;
 
+    const usage = { ...client.usage };
+
     const { conversation = {} } = await client.responsePromise;
     conversation.title =
       conversation && !conversation.title ? null : conversation?.title || 'New Chat';
@@ -121,14 +123,14 @@ const AskController = async (req, res, next, initializeClient, addTitle) => {
         conversation,
         title: conversation.title,
         requestMessage: userMessage,
-        responseMessage: response,
+        responseMessage: { ...response, tmp_usage: usage },
       });
       res.end();
 
       if (!client.savedMessageIds.has(response.messageId)) {
         await saveMessage(
           req,
-          { ...response, user },
+          { ...response, user, usage },
           { context: 'api/server/controllers/AskController.js - response end' },
         );
       }

--- a/client/src/components/Chat/ChatView.tsx
+++ b/client/src/components/Chat/ChatView.tsx
@@ -64,6 +64,8 @@ function ChatView({ index = 0 }: { index?: number }) {
     content = <Landing centerFormOnLanding={centerFormOnLanding} />;
   }
 
+  const conversationCost = calculateTotalCost(messagesTree);
+
   return (
     <ChatFormProvider {...methods}>
       <ChatContext.Provider value={chatHelpers}>
@@ -88,7 +90,11 @@ function ChatView({ index = 0 }: { index?: number }) {
                   {content}
                   <div className="w-full">
                     <ChatForm index={index} />
-                    <Footer />
+                    <Footer
+                      additionalText={
+                        conversationCost > 0 ? `Conversation Cost: $${conversationCost.toFixed(3)}` : undefined
+                      }
+                    />
                   </div>
                 </div>
               )}
@@ -98,6 +104,18 @@ function ChatView({ index = 0 }: { index?: number }) {
       </ChatContext.Provider>
     </ChatFormProvider>
   );
+}
+
+function calculateTotalCost(messagesTree?: TMessage[] | null): number {
+  if (!messagesTree) {
+    return 0;
+  }
+
+  return messagesTree
+    .map((msg) => {
+      return ((msg as any)?.tmp_usage?.cost || 0) + calculateTotalCost(msg?.children);
+    })
+    .reduce((acc, curr) => acc + curr, 0);
 }
 
 export default memo(ChatView);

--- a/client/src/components/Chat/Footer.tsx
+++ b/client/src/components/Chat/Footer.tsx
@@ -5,7 +5,13 @@ import { Constants } from 'librechat-data-provider';
 import { useGetStartupConfig } from '~/data-provider';
 import { useLocalize } from '~/hooks';
 
-export default function Footer({ className }: { className?: string }) {
+export default function Footer({
+  className,
+  additionalText,
+}: {
+  className?: string;
+  additionalText?: string;
+}) {
   const { data: config } = useGetStartupConfig();
   const localize = useLocalize();
 
@@ -14,7 +20,7 @@ export default function Footer({ className }: { className?: string }) {
 
   const privacyPolicyRender = privacyPolicy?.externalUrl != null && (
     <a
-      className="text-text-secondary underline"
+      className="text-text-tertiary underline"
       href={privacyPolicy.externalUrl}
       target={privacyPolicy.openNewTab === true ? '_blank' : undefined}
       rel="noreferrer"
@@ -25,7 +31,7 @@ export default function Footer({ className }: { className?: string }) {
 
   const termsOfServiceRender = termsOfService?.externalUrl != null && (
     <a
-      className="text-text-secondary underline"
+      className="text-text-tertiary underline"
       href={termsOfService.externalUrl}
       target={termsOfService.openNewTab === true ? '_blank' : undefined}
       rel="noreferrer"
@@ -43,6 +49,10 @@ export default function Footer({ className }: { className?: string }) {
         localize('com_ui_latest_footer')
   ).split('|');
 
+  if (additionalText) {
+    mainContentParts.unshift(additionalText);
+  }
+
   useEffect(() => {
     if (config?.analyticsGtmId != null && typeof window.google_tag_manager === 'undefined') {
       const tagManagerArgs = {
@@ -59,7 +69,7 @@ export default function Footer({ className }: { className?: string }) {
           a: ({ node: _n, href, children, ...otherProps }) => {
             return (
               <a
-                className="text-text-secondary underline"
+                className="text-text-tertiary underline"
                 href={href}
                 target="_blank"
                 rel="noreferrer"
@@ -87,7 +97,7 @@ export default function Footer({ className }: { className?: string }) {
       <div
         className={
           className ??
-          'absolute bottom-0 left-0 right-0 hidden items-center justify-center gap-2 px-2 py-2 text-center text-xs text-text-primary sm:flex md:px-[60px]'
+          'absolute bottom-0 left-0 right-0 hidden items-center justify-center gap-2 px-2 py-2 text-center text-xs text-text-tertiary sm:flex md:px-[60px]'
         }
         role="contentinfo"
       >

--- a/client/src/components/Chat/Messages/Content/MessageContent.tsx
+++ b/client/src/components/Chat/Messages/Content/MessageContent.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable i18next/no-literal-string */
 import { memo, Suspense, useMemo } from 'react';
 import { useRecoilValue } from 'recoil';
 import type { TMessage } from 'librechat-data-provider';
@@ -166,9 +167,34 @@ const MessageContent = ({
         text={regularContent}
         {...props}
       />
+      {!!(props.message as any).tmp_usage &&
+        (() => {
+          const usage = (props.message as any).tmp_usage;
+          const input = usage.prompt_tokens || 0;
+          const cachedInput = usage.prompt_tokens_details?.cached_tokens || 0;
+          const output = usage.completion_tokens || 0;
+          const cost = usage.cost || 0;
+
+          return (
+            <div className="text-xs text-gray-300 dark:text-gray-600">
+              ↑ {formatTokensUsage(input)}{' '}
+              {cachedInput > 0 ? (
+                <span className="text-xs">({formatTokensUsage(cachedInput)} cached)</span>
+              ) : (
+                ''
+              )}{' '}
+              · ↓ {formatTokensUsage(output)} · $
+              {Math.max(Math.ceil(cost * 1000) / 1000, 0.001).toFixed(3)}
+            </div>
+          );
+        })()}
       {unfinishedMessage}
     </>
   );
 };
 
 export default memo(MessageContent);
+
+function formatTokensUsage(tokens: number) {
+  return tokens > 1000 ? (tokens / 1000).toFixed(1) + 'kt' : tokens.toString() + 't';
+}

--- a/packages/data-schemas/src/schema/message.ts
+++ b/packages/data-schemas/src/schema/message.ts
@@ -35,6 +35,7 @@ export interface IMessage extends Document {
   expiredAt?: Date;
   createdAt?: Date;
   updatedAt?: Date;
+  tmp_usage?: unknown;
 }
 
 const messageSchema: Schema<IMessage> = new Schema(
@@ -173,6 +174,9 @@ const messageSchema: Schema<IMessage> = new Schema(
     */
     expiredAt: {
       type: Date,
+    },
+    tmp_usage: {
+      type: Object,
     },
   },
   { timestamps: true },


### PR DESCRIPTION
_Update: for more recent rebases of this change, please refer to the https://github.com/zetavg/LibreChat/tree/patches and https://github.com/zetavg/LibreChat/tree/patches-2 branches._

Temporary hack to display token usage and cost to raise awareness, especially for long GPT-4.5 conversations, which can be costly due to extensive input as the conversation grows.

![](https://github.com/user-attachments/assets/1b3e6a83-8c5e-47e0-9aa2-dd8fe0c57208)

![](https://github.com/user-attachments/assets/f4da6cf3-948b-459f-b39f-5609ae799e49)

Using the token usage data from the API response. Handles [prompt caching](https://openai.com/index/api-prompt-caching/) and can calculate the correct cost based on the cached prompt.

![](https://github.com/user-attachments/assets/dc1707c1-ee6c-4a72-aed6-afe1d1dc0b67)

## Known Issues

* Only works for explicitly listed models of OpenAI.
* Cannot calculate the cost for aborted generations since idk how to get the usage data if it's aborted.